### PR TITLE
Slot: unscheduled sessions should not keep the model from validating

### DIFF
--- a/src/pytanis/pretalx/types.py
+++ b/src/pytanis/pretalx/types.py
@@ -90,10 +90,10 @@ class Speaker(SubmissionSpeaker):
 
 
 class Slot(BaseModel):
-    start: datetime
-    end: datetime
-    room: MultiLingualStr
-    room_id: int
+    start: datetime | None
+    end: datetime | None
+    room: MultiLingualStr | None
+    room_id: int | None
 
 
 class Resource(BaseModel):


### PR DESCRIPTION
In early conference stages slots are not assigned yet. Not having a start/end times or a room keeps the model from validating. We need to make the attrs optional so`Submissions` can be loaded and validated at early stages as well.